### PR TITLE
Add back organizations method without pagination

### DIFF
--- a/app/models/copilot/enterprise.rb
+++ b/app/models/copilot/enterprise.rb
@@ -6,6 +6,8 @@ require_relative 'metric_calculations'
 require_relative 'organization'
 require 'parallel'
 
+require 'pry'
+
 module Copilot
   # Access Copilot Enterprise metrics from the GitHub API
   class Enterprise
@@ -89,12 +91,23 @@ module Copilot
     end
 
     def organizations
+      response = GraphQLAPI::Client.query(
+        GraphQLQueries::EnterpriseOrganizationsQuery,
+        variables: { slug: ent }
+      )
+
+      response.data.enterprise.organizations.to_h['nodes']
+    end
+
+    def all_organizations
+      # Allows to return all organizations when an Enterprise has greater than 100 organizations
+      # This is more orgs than most should have, but it's possible
       after_cursor = nil
       organizations = []
 
       loop do
         response = GraphQLAPI::Client.query(
-          GraphQLQueries::EnterpriseOrganizationsQuery,
+          GraphQLQueries::EnterpriseAllOrganizationsQuery,
           variables: { slug: ent, after: after_cursor }
         )
 
@@ -109,3 +122,7 @@ module Copilot
     end
   end
 end
+
+ent = Copilot::Enterprise.new
+binding.pry
+puts ent

--- a/app/services/graphql_queries.rb
+++ b/app/services/graphql_queries.rb
@@ -2,6 +2,22 @@ require_relative 'graphql_api'
 
 module GraphQLQueries
   EnterpriseOrganizationsQuery = GraphQLAPI::Client.parse <<~'GRAPHQL'
+    query($slug: String!) {
+      enterprise(slug: $slug) {
+        name
+        organizations(first:100){
+          nodes{
+            name
+            ... on Organization{
+              login
+            }
+          }
+        }
+      }
+    }
+  GRAPHQL
+
+  EnterpriseAllOrganizationsQuery = GraphQLAPI::Client.parse <<~'GRAPHQL'
     query($slug: String!, $after: String) {
       enterprise(slug: $slug) {
         name


### PR DESCRIPTION
This pull request includes several changes to the `Copilot` enterprise metrics functionality, primarily focusing on querying and handling organizations within an enterprise. The most important changes include the addition of new GraphQL queries, the introduction of new methods to handle larger sets of organizations, and some debugging code.