### PR TITLE
Add Copilot Enterprise and License endpoints

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,28 +1,51 @@
 # frozen_string_literal: true
 
 require_relative 'application_controller'
-require_relative '../models/copilot'
-require 'sinatra'
+require_relative '../models/copilot/enterprise'
+require_relative '../models/copilot/organization'
 
 class ApiController < ApplicationController
   get '/' do
     puts 'This should lead to some sort of configuration'
   end
 
-  get '/copilot/:org/daily_summary' do
+  # Organization level Copilot metrics
+
+  get '/copilot/organization/:org/daily_summary' do
     org = params['org']
-    copilot = Copilot.new(org: org)
+    copilot = Copilot::Organization.new(org: org)
     copilot.daily_org_summary.to_json
   end
 
-  get '/copilot/:org/team/:team_slug/daily_summary' do
+  get '/copilot/organization/:org/team/:team_slug/daily_summary' do
     org = params['org']
     team_slug = params['team_slug']
-    copilot = Copilot.new(org: org, team_slug: team_slug)
+    copilot = Copilot::Organization.new(org: org, team_slug: team_slug)
     copilot.daily_team_summary.to_json
   end
 
-  get '/pull_request/:org/:repo/lines_of_code' do
+  get '/copilot/organization/:org/license_breakdown' do
+    org = params['org']
+    copilot = Copilot::Organization.new(org: org)
+    copilot.license_breakdown.to_json
+  end
+
+  # Enterprise level Copilot metrics
+
+  get '/copilot/enterprise/:ent/daily_summary' do
+    ent = params['ent']
+    enterprise = Copilot::Enterprise.new(ent: ent)
+    enterprise.daily_summary.to_json
+  end
+
+  get '/copilot/enterprise/:ent/license_breakdown' do
+    ent = params['ent']
+    enterprise = Copilot::Enterprise.new(ent: ent)
+    enterprise.license_breakdown.to_json
+  end
+
+  # Pull Request metrics
+  get '/pull_request/organization/:org/repository/:repo/lines_of_code' do
     org = params['org']
     repo = params['repo']
     pr = PullRequest.new(org: org, repo: repo)

--- a/app/models/copilot/enterprise.rb
+++ b/app/models/copilot/enterprise.rb
@@ -122,7 +122,3 @@ module Copilot
     end
   end
 end
-
-ent = Copilot::Enterprise.new
-binding.pry
-puts ent


### PR DESCRIPTION
This pull request includes changes to the `ApiController` to support new endpoints for organization and enterprise-level Copilot metrics, and removes debugging code from the `Copilot::Enterprise` model.